### PR TITLE
fix: Clean up language switching and add server-side language detection

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,10 +13,6 @@ export const metadata: Metadata = {
   description: "A blog about web development and other stuff",
 };
 
-export function generateStaticParams() {
-  return i18nConfig.locales.map((locale) => ({ locale }));
-}
-
 const RootLayout = async ({ children }: { children: React.ReactNode }) => {
   const { resources, i18n } = await initTranslations();
   const detectedLanguage =

--- a/middleware.js
+++ b/middleware.js
@@ -1,18 +1,26 @@
 import { NextResponse } from "next/server";
 
 export function middleware(request) {
-  const { nextUrl } = request;
-  const urlLocale = nextUrl.locale || "kr";
-  const supportedLocales = ["en", "kr"];
-  const defaultLocale = "kr";
+  const langCookie = request.cookies.get("lang")?.value;
 
-  // Check if the requested locale is supported, else redirect to default
-  if (!supportedLocales.includes(urlLocale)) {
-    nextUrl.locale = defaultLocale;
-    return NextResponse.redirect(nextUrl);
+  // If lang cookie already exists, skip detection
+  if (langCookie) {
+    return NextResponse.next();
   }
 
-  return NextResponse.next();
+  // Detect language from Accept-Language header on first visit
+  const acceptLanguage = request.headers.get("accept-language") || "";
+  const detectedLang = acceptLanguage.toLowerCase().startsWith("en")
+    ? "en"
+    : "kr";
+
+  const response = NextResponse.next();
+  response.cookies.set("lang", detectedLang, {
+    maxAge: 60 * 60 * 24 * 365,
+    path: "/",
+  });
+
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Replaced dead middleware locale logic with `Accept-Language` header detection
- First-time visitors now get language auto-detected from browser preference
- Removed unused `generateStaticParams` from layout (leftover from previous i18n setup)

## Changed Files
- `middleware.js`
- `app/layout.tsx`