### PR TITLE
feat: integrate Vercel Web Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "~styles/globals.css";
 
 import { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/react";
 import Header from "~components/header";
 import ThemeProvider from "~styles/themeProvider";
 import i18nConfig from "../next-i18next.config";
@@ -51,6 +52,7 @@ const RootLayout = async ({ children }: { children: React.ReactNode }) => {
             </div>
           </ThemeProvider>
         </TranslationProvider>
+        <Analytics />
       </body>
     </html>
   );

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
     "@types/remark-prism": "^1.3.6",
+    "@vercel/analytics": "^2.0.1",
     "autoprefixer": "10.4.15",
     "class-variance-authority": "^0.7.0",
     "cmdk": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,6 +2068,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/analytics@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@vercel/analytics@npm:2.0.1"
+  peerDependencies:
+    "@remix-run/react": ^2
+    "@sveltejs/kit": ^1 || ^2
+    next: ">= 13"
+    nuxt: ">= 3"
+    react: ^18 || ^19 || ^19.0.0-rc
+    svelte: ">= 4"
+    vue: ^3
+    vue-router: ^4
+  peerDependenciesMeta:
+    "@remix-run/react":
+      optional: true
+    "@sveltejs/kit":
+      optional: true
+    next:
+      optional: true
+    nuxt:
+      optional: true
+    react:
+      optional: true
+    svelte:
+      optional: true
+    vue:
+      optional: true
+    vue-router:
+      optional: true
+  checksum: 10c0/c788c03d0f072f6f2be52d3f6f4f0680d2343f0d8765a759a044204223b14a6e14b285d0c5d5d05c0b66d4419746c5b245656ebdc48398328d85d96f1ede982b
+  languageName: node
+  linkType: hard
+
 "abab@npm:^2.0.3, abab@npm:^2.0.5":
   version: 2.0.6
   resolution: "abab@npm:2.0.6"
@@ -7738,6 +7771,7 @@ __metadata:
     "@types/react": "npm:18.2.21"
     "@types/react-dom": "npm:18.2.7"
     "@types/remark-prism": "npm:^1.3.6"
+    "@vercel/analytics": "npm:^2.0.1"
     autoprefixer: "npm:10.4.15"
     class-variance-authority: "npm:^0.7.0"
     clsx: "npm:^2.0.0"


### PR DESCRIPTION
## Summary
- Add `@vercel/analytics` (v2.0.1) as a dependency
- Mount `<Analytics />` in `app/layout.tsx` (placed outside provider tree, just before `</body>`) to enable cookieless page view tracking via the Vercel dashboard

## Why
Vercel Web Analytics gives privacy-friendly visitor and page view metrics out of the box without setting up Google Analytics. It also avoids cookie banners since it does not store personal data.

## Follow-up
After merge, enable the **Analytics** tab in the Vercel project dashboard so collected events start showing up.

## Test plan
- [x] `yarn build` passes locally
- [ ] After deploy, confirm page views appear in the Vercel Analytics dashboard