### PR TITLE
fix: use @vercel/analytics/next import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import "~styles/globals.css";
 import { Metadata } from "next";
-import { Analytics } from "@vercel/analytics/react";
+import { Analytics } from "@vercel/analytics/next";
 
 const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL || "https://if-geon.xyz";


### PR DESCRIPTION
## Summary
- Analytics import path를 `@vercel/analytics/react` → `@vercel/analytics/next`로 변경
- Vercel 공식 문서 권장 사항으로 Next.js 전용 최적화 적용

Replaces #14 (Vercel Agent PR - conflict + 불필요한 yarn.lock 재생성 이슈)

## Test plan
- [x] `yarn build` 성공 확인