### PR TITLE
fix: improve SEO indexing for /posts page

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -14,6 +14,7 @@ function buildPostAlternates(slug: string): Record<string, string> {
   for (const locale of available) {
     languages[locale] = `${SITE_URL}/${locale}/posts/${slug}`;
   }
+  languages["x-default"] = `${SITE_URL}/en/posts/${slug}`;
   return languages;
 }
 
@@ -32,6 +33,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
         languages: {
           ko: `${SITE_URL}/ko/posts`,
           en: `${SITE_URL}/en/posts`,
+          "x-default": `${SITE_URL}/en/posts`,
         },
       },
     });
@@ -48,6 +50,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
         languages: {
           ko: `${SITE_URL}/ko/resume`,
           en: `${SITE_URL}/en/resume`,
+          "x-default": `${SITE_URL}/en/resume`,
         },
       },
     });

--- a/next.config.js
+++ b/next.config.js
@@ -18,17 +18,17 @@ module.exports = withMDX({
       {
         source: "/posts",
         destination: "/ko/posts",
-        permanent: false,
+        permanent: true,
       },
       {
         source: "/posts/:slug*",
         destination: "/ko/posts/:slug*",
-        permanent: false,
+        permanent: true,
       },
       {
         source: "/resume",
         destination: "/ko/resume",
-        permanent: false,
+        permanent: true,
       },
     ];
   },


### PR DESCRIPTION
## Summary
- Google Search Console에서 `/posts` 페이지 색인 누락 알림 대응
- 레거시 리다이렉트(`/posts`, `/posts/:slug*`, `/resume`)를 307(임시) → 308(영구)로 변경하여 Google이 대상 URL을 정식으로 색인하도록 개선
- 사이트맵 전체 항목에 `x-default` hreflang 추가하여 Google 다국어 가이드라인 충족

## Test plan
- [ ] 배포 후 `/sitemap.xml`에 `x-default` hreflang 태그 포함 확인
- [ ] `/posts` 접근 시 308 응답 코드로 `/ko/posts` 리다이렉트 확인
- [ ] Google Search Console에서 `/ko/posts`, `/en/posts` URL 검사 → 색인 생성 요청

🤖 Generated with [Claude Code](https://claude.com/claude-code)