### PR TITLE
Port improvements from create-next-log

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import localFont from "next/font/local";
 import { notFound } from "next/navigation";
 import Header from "~components/header";
+import GoogleAnalytics from "~components/GoogleAnalytics";
 import ThemeProvider from "~styles/themeProvider";
 import TranslationProvider from "~core/translation/translationProvider";
 import initTranslations from "../../i18n";
@@ -79,12 +80,36 @@ const LangLayout = async ({
 
   return (
     <html suppressHydrationWarning lang={lang} className={pretendard.variable}>
-      <body className={pretendard.className}>
+      <body suppressHydrationWarning className={pretendard.className}>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-background focus:text-foreground focus:rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+        >
+          Skip to content
+        </a>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "WebSite",
+              name: "Geon log",
+              description:
+                lang === "ko"
+                  ? "웹 개발과 기타 주제에 관한 블로그"
+                  : "A blog about web development and other stuff",
+              url: "https://if-geon.xyz",
+            }),
+          }}
+        />
+        {process.env.NEXT_PUBLIC_GA_ID && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+        )}
         <TranslationProvider lang={lang} resources={resources}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
             <Header />
             <div className="flex w-full justify-center">
-              <main className="container relative lg:px-8">{children}</main>
+              <main id="main-content" className="container relative lg:px-8">{children}</main>
             </div>
           </ThemeProvider>
         </TranslationProvider>

--- a/app/components/GoogleAnalytics.tsx
+++ b/app/components/GoogleAnalytics.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Script from "next/script";
+
+interface Props {
+  gaId: string;
+}
+
+export default function GoogleAnalytics({ gaId }: Props) {
+  if (!gaId) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${gaId}');
+        `}
+      </Script>
+    </>
+  );
+}

--- a/app/components/mdx/CodeBlock.tsx
+++ b/app/components/mdx/CodeBlock.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState, useRef } from "react";
+
+export function CodeBlock(props: React.HTMLAttributes<HTMLPreElement>) {
+  const [copied, setCopied] = useState(false);
+  const preRef = useRef<HTMLPreElement>(null);
+
+  const handleCopy = async () => {
+    const code = preRef.current?.querySelector("code")?.textContent || "";
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="relative group">
+      <button
+        onClick={handleCopy}
+        className="absolute right-3 top-3 z-10 rounded-md px-2 py-1 text-xs opacity-0 group-hover:opacity-100 transition-opacity bg-muted/80 hover:bg-muted text-muted-foreground"
+        aria-label="Copy code"
+      >
+        {copied ? "Copied!" : "Copy"}
+      </button>
+      <pre ref={preRef} {...props} />
+    </div>
+  );
+}

--- a/app/components/mdx/MdxRenderer.tsx
+++ b/app/components/mdx/MdxRenderer.tsx
@@ -3,8 +3,6 @@ import rehypeSlug from "rehype-slug";
 import rehypeCodeTitles from "rehype-code-titles";
 import rehypePrism from "rehype-prism-plus";
 import rehypeExternalLinks from "rehype-external-links";
-// @ts-ignore
-import rehypeAddClasses from "rehype-add-classes";
 import remarkGfm from "remark-gfm";
 import { mdxComponents } from "./index";
 
@@ -22,7 +20,6 @@ export function MdxRenderer({ source }: MdxRendererProps) {
           remarkPlugins: [remarkGfm],
           rehypePlugins: [
             rehypeSlug,
-            [rehypeAddClasses, { "h1,h2": "heading" }],
             rehypeCodeTitles,
             [rehypePrism, { ignoreMissing: true }] as any,
             [

--- a/app/components/mdx/index.ts
+++ b/app/components/mdx/index.ts
@@ -1,7 +1,9 @@
 import { Timeline, TimelineItem } from "./Timeline";
 import { FileTree, Folder, File } from "./FileTree";
+import { CodeBlock } from "./CodeBlock";
 
 export const mdxComponents = {
+  pre: CodeBlock,
   Timeline,
   TimelineItem,
   FileTree,

--- a/app/core/blog/markdownToHtml.ts
+++ b/app/core/blog/markdownToHtml.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import rehypeAddClasses from "rehype-add-classes";
 import rehypeCodeTitles from "rehype-code-titles";
 import rehypeExternalLinks from "rehype-external-links";
 import rehypePrism from "rehype-prism-plus";
@@ -16,7 +14,6 @@ export default async function markdownToHtml(markdown: string) {
     .use(remarkGfm)
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeSlug)
-    .use(rehypeAddClasses, { "h1,h2": "heading" })
     .use(rehypeCodeTitles)
     .use(rehypePrism, { ignoreMissing: true })
     .use(rehypeExternalLinks, {

--- a/next.config.js
+++ b/next.config.js
@@ -4,9 +4,20 @@ const withMDX = require("@next/mdx")({
   extension: /\.mdx?$/,
 });
 
+const securityHeaders = [
+  { key: "X-DNS-Prefetch-Control", value: "on" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
 module.exports = withMDX({
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
   reactStrictMode: true,
+  async headers() {
+    return [{ source: "/(.*)", headers: securityHeaders }];
+  },
   async redirects() {
     // Defensive redirects for legacy URLs without a locale prefix.
     // Default to /ko since these URLs were the original Korean blog paths

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "postcss": "8.4.29",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rehype-add-classes": "^1.0.0",
     "rehype-code-titles": "^1.2.0",
     "rehype-external-links": "^3.0.0",
     "rehype-stringify": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,13 +2148,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"boolbase@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "boolbase@npm:1.0.0"
-  checksum: 10c0/e4b53deb4f2b85c52be0e21a273f2045c7b6a6ea002b0e139c744cb6f95e9ec044439a52883b0d74dedd1ff3da55ed140cfdddfed7fb0cccbed373de5dce1bcf
-  languageName: node
-  linkType: hard
-
 "brace-expansion@npm:^1.1.7":
   version: 1.1.14
   resolution: "brace-expansion@npm:1.1.14"
@@ -2277,13 +2270,6 @@ __metadata:
   version: 2.0.1
   resolution: "camelcase-css@npm:2.0.1"
   checksum: 10c0/1a1a3137e8a781e6cbeaeab75634c60ffd8e27850de410c162cce222ea331cd1ba5364e8fb21c95e5ca76f52ac34b81a090925ca00a87221355746d049c6e273
-  languageName: node
-  linkType: hard
-
-"camelcase@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "camelcase@npm:3.0.0"
-  checksum: 10c0/98871bb40b936430beca49490d325759f8d8ade32bea538ee63c20b17b326abb6bbd3e1d84daf63d9332b2fc7637f28696bf76da59180b1247051b955cb1da12
   languageName: node
   linkType: hard
 
@@ -2423,13 +2409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"comma-separated-tokens@npm:^1.0.2":
-  version: 1.0.8
-  resolution: "comma-separated-tokens@npm:1.0.8"
-  checksum: 10c0/c3bcfeaa6d50313528a006a40bcc0f9576086665c9b48d4b3a76ddd63e7d6174734386c98be1881cbf6ecfc25e1db61cd775a7b896d2ea7a65de28f83a0f9b17
-  languageName: node
-  linkType: hard
-
 "comma-separated-tokens@npm:^2.0.0":
   version: 2.0.3
   resolution: "comma-separated-tokens@npm:2.0.3"
@@ -2459,13 +2438,6 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
-  languageName: node
-  linkType: hard
-
-"css-selector-parser@npm:^1.3.0":
-  version: 1.4.1
-  resolution: "css-selector-parser@npm:1.4.1"
-  checksum: 10c0/4a89a7b61072cf0e4d09e8abbb9a77bc661232b6fe6a6fe51ba775757bae0e3fc462b0db4c9a857da55afb89a1c1746a7b2ec1200f639c539556ebdc758b0101
   languageName: node
   linkType: hard
 
@@ -3754,26 +3726,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hast-util-has-property@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "hast-util-has-property@npm:1.0.4"
-  checksum: 10c0/dcad2e0fc6e2e13b42028ccec40cea5f607ea5fd0c38706467e546df52a5ed5db95c94ba29028855a6024d7a571d7d3dc55403fc16e370f580187716d48865ef
-  languageName: node
-  linkType: hard
-
 "hast-util-heading-rank@npm:^3.0.0":
   version: 3.0.0
   resolution: "hast-util-heading-rank@npm:3.0.0"
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10c0/1879c84f629e73f1f13247ab349324355cd801363b44e3d46f763aa5c0ea3b42dcd47b46e5643a0502cf01a6b1fdb9208fd12852e44ca6c671b3e4bccf9369a1
-  languageName: node
-  linkType: hard
-
-"hast-util-is-element@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "hast-util-is-element@npm:1.1.0"
-  checksum: 10c0/9f95b1e356af3d891a293c1e63560480cb9c2aa33c14e0da3abfaf76aa3f2de8e178643f8459b10e1e2d11a0bc4553c628b57e5afa607791073b61d456f77926
   languageName: node
   linkType: hard
 
@@ -3792,25 +3750,6 @@ __metadata:
   dependencies:
     "@types/hast": "npm:^2.0.0"
   checksum: 10c0/34ac1707a477fd9764e328087163f1f21857bdb0f8d425bf41f6def7baf840e50e4bca2eb03072e3da4e39856de28893c4b688dcba0cc305160d53afcece4df4
-  languageName: node
-  linkType: hard
-
-"hast-util-select@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "hast-util-select@npm:1.0.1"
-  dependencies:
-    camelcase: "npm:^3.0.0"
-    comma-separated-tokens: "npm:^1.0.2"
-    css-selector-parser: "npm:^1.3.0"
-    hast-util-has-property: "npm:^1.0.0"
-    hast-util-is-element: "npm:^1.0.0"
-    hast-util-whitespace: "npm:^1.0.0"
-    not: "npm:^0.1.0"
-    nth-check: "npm:^1.0.1"
-    property-information: "npm:^3.1.0"
-    space-separated-tokens: "npm:^1.1.0"
-    zwitch: "npm:^1.0.0"
-  checksum: 10c0/670ffdcdded6e75156e0677c6dce6e9cd8e5d2230f4c15d8da75a4f2c0b999455fb9f480937289a5e22fe4078999a413b1184243451852e6c5aed65aca871a56
   languageName: node
   linkType: hard
 
@@ -3918,13 +3857,6 @@ __metadata:
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10c0/b5fa1912a6ba6131affae52a0f4394406c4c0d23c2b0307f1d69988f1030c7bb830289303e67c5ad8f674f5f23a454c1dcd492c39e45a22c1f46d3c9bce5bd0c
-  languageName: node
-  linkType: hard
-
-"hast-util-whitespace@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "hast-util-whitespace@npm:1.0.4"
-  checksum: 10c0/434771896f151bca2954d3946f113dfbb8902e6305fa49d470ff2422c2b8c04b784490ecfacc26b2412c5dabfbc2ae1a1051c0ed0ca1c587e41204b5c0105d61
   languageName: node
   linkType: hard
 
@@ -6124,7 +6056,6 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-i18next: "npm:^14.1.2"
-    rehype-add-classes: "npm:^1.0.0"
     rehype-autolink-headings: "npm:^7.0.0"
     rehype-code-titles: "npm:^1.2.0"
     rehype-external-links: "npm:^3.0.0"
@@ -6292,22 +6223,6 @@ __metadata:
   version: 0.1.2
   resolution: "normalize-range@npm:0.1.2"
   checksum: 10c0/bf39b73a63e0a42ad1a48c2bd1bda5a07ede64a7e2567307a407674e595bcff0fa0d57e8e5f1e7fa5e91000797c7615e13613227aaaa4d6d6e87f5bd5cc95de6
-  languageName: node
-  linkType: hard
-
-"not@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "not@npm:0.1.0"
-  checksum: 10c0/b75d7b2e41d73e2e1cb3327826d53667b41bc6ff7d7ff1d8014ad3bf410d4ecd46f512683b22a4c043e03cbb2b0a483aa69232d4bf9c0e2ee1a9127fe02f047a
-  languageName: node
-  linkType: hard
-
-"nth-check@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "nth-check@npm:1.0.2"
-  dependencies:
-    boolbase: "npm:~1.0.0"
-  checksum: 10c0/1a67ce53a99e276eea672f892d712b29f3e6802bbbef7285ffab72ecea4f972e8244defac1ebded0daffabf459def31355bb9c64e5657ac2ab032c13f185d0fd
   languageName: node
   linkType: hard
 
@@ -6736,13 +6651,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"property-information@npm:^3.1.0":
-  version: 3.2.0
-  resolution: "property-information@npm:3.2.0"
-  checksum: 10c0/d277be23e1eabc715f04c8447438a034921eca615e1c876d963f94bb174f7d0e4e2286ba97c9ee85d1bccec3eb2db21f99ad5782aac6dcdc9901d3e210a756ba
-  languageName: node
-  linkType: hard
-
 "property-information@npm:^6.0.0":
   version: 6.5.0
   resolution: "property-information@npm:6.5.0"
@@ -6994,15 +6902,6 @@ __metadata:
     gopd: "npm:^1.2.0"
     set-function-name: "npm:^2.0.2"
   checksum: 10c0/83b88e6115b4af1c537f8dabf5c3744032cb875d63bc05c288b1b8c0ef37cbe55353f95d8ca817e8843806e3e150b118bc624e4279b24b4776b4198232735a77
-  languageName: node
-  linkType: hard
-
-"rehype-add-classes@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "rehype-add-classes@npm:1.0.0"
-  dependencies:
-    hast-util-select: "npm:^1.0.1"
-  checksum: 10c0/1e8bdd020b5b22c20fe468761d94885d9c868bed57087fcc627b215e198636e23a3bcabe7b75856938f4d216f72add73da541abe21051062244fa9c0c591c206
   languageName: node
   linkType: hard
 
@@ -7564,13 +7463,6 @@ __metadata:
   version: 0.7.6
   resolution: "source-map@npm:0.7.6"
   checksum: 10c0/59f6f05538539b274ba771d2e9e32f6c65451982510564438e048bc1352f019c6efcdc6dd07909b1968144941c14015c2c7d4369fb7c4d7d53ae769716dcc16c
-  languageName: node
-  linkType: hard
-
-"space-separated-tokens@npm:^1.1.0":
-  version: 1.1.5
-  resolution: "space-separated-tokens@npm:1.1.5"
-  checksum: 10c0/3ee0a6905f89e1ffdfe474124b1ade9fe97276a377a0b01350bc079b6ec566eb5b219e26064cc5b7f3899c05bde51ffbc9154290b96eaf82916a1e2c2c13ead9
   languageName: node
   linkType: hard
 
@@ -8675,13 +8567,6 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
-  languageName: node
-  linkType: hard
-
-"zwitch@npm:^1.0.0":
-  version: 1.0.5
-  resolution: "zwitch@npm:1.0.5"
-  checksum: 10c0/26dc7d32e5596824b565db1da9650d00d32659c1211195bef50c25c60820f9c942aa7abefe678fc1ed0b97c1755036ac1bde5f97881d7d0e73e04e02aca56957
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, X-DNS-Prefetch-Control)
- Remove `rehype-add-classes` package (known vulnerabilities, unused CSS class)
- Add skip-to-content accessibility link and `suppressHydrationWarning` on body
- Add JSON-LD structured data (WebSite schema) for SEO
- Add Google Analytics component (opt-in via `NEXT_PUBLIC_GA_ID` env var)
- Add CodeBlock component with hover copy button for code blocks

## Test plan
- [x] `yarn build` passes successfully
- [ ] Verify security headers appear in response (check dev tools Network tab)
- [ ] Verify code copy button appears on hover over code blocks
- [ ] Verify JSON-LD script tag in page source
- [ ] Verify skip-to-content link is focusable via Tab key