### PR TITLE
fix: swap dark/light mode toggle icons

### DIFF
--- a/app/components/header/toggle/index.tsx
+++ b/app/components/header/toggle/index.tsx
@@ -55,9 +55,9 @@ function NavToggles() {
         onClick={changeTheme}
       >
         {mounted && resolvedTheme === "dark" ? (
-          <MoonIcon className="h-4 w-4" />
-        ) : (
           <SunIcon className="h-4 w-4" />
+        ) : (
+          <MoonIcon className="h-4 w-4" />
         )}
       </Button>
     </nav>


### PR DESCRIPTION
## Summary
- 다크/라이트 모드 토글 아이콘이 반대로 표시되던 버그 수정
- 다크모드에서 SunIcon(라이트 전환), 라이트모드에서 MoonIcon(다크 전환) 표시