### PR TITLE
fix: scope inline code styles to prevent code block regression

### DIFF
--- a/app/styles/prism.css
+++ b/app/styles/prism.css
@@ -35,7 +35,7 @@ pre {
 }
 
 /* lab(47.8876% 63.025 42.31 */
-code {
+:not(pre) > code {
   background: var(--code-inline-highlight-background);
   border: 1px solid var(--code-inline-highlight-border);
   padding: 0.125rem 0.25em;


### PR DESCRIPTION
## Summary
- Fix code block rendering issue caused by Tailwind CSS 4 migration (PR #27 side effect)
- Change `code` selector to `:not(pre) > code` in prism.css so inline code styles (background, border, display:inline-block) don't leak into `pre > code`

## Root cause
Tailwind 3's typography plugin reset `pre code` styles, but Tailwind 4 no longer overrides them, causing double backgrounds in code blocks.

## Test plan
- [x] Verified code blocks render correctly on localhost
- [x] Verified inline code styling is unaffected