### PR TITLE
fix: use www subdomain for site URL to match Search Console

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_SITE_URL=https://if-geon.xyz
+NEXT_PUBLIC_SITE_URL=https://www.if-geon.xyz

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -100,7 +100,7 @@ const LangLayout = async ({
                 lang === "ko"
                   ? "웹 개발과 기타 주제에 관한 블로그"
                   : "A blog about web development and other stuff",
-              url: "https://if-geon.xyz",
+              url: "https://www.if-geon.xyz",
             }),
           }}
         />


### PR DESCRIPTION
## Summary
- Changed `NEXT_PUBLIC_SITE_URL` from `https://if-geon.xyz` to `https://www.if-geon.xyz` in `.env.production`
- Fixed hardcoded URL in JSON-LD schema (`app/[lang]/layout.tsx`)
- This resolves the sitemap read failure in Google Search Console, which was caused by URL mismatch between the registered property (`www.if-geon.xyz`) and generated sitemap/meta URLs (`if-geon.xyz`)

## Test plan
- [ ] Verify `https://www.if-geon.xyz/sitemap.xml` contains `www` URLs after deploy
- [ ] Verify `https://www.if-geon.xyz/robots.txt` points to `www` sitemap
- [ ] Re-submit sitemap in Search Console and confirm it reads successfully